### PR TITLE
Issue4/allow import as

### DIFF
--- a/lib/combine.js
+++ b/lib/combine.js
@@ -217,6 +217,19 @@ const alterNameForCombine = filename => (
 );
 
 /**
+ * given a list of file objects, check if any are using the import 'as' syntax
+ * this can be found in the containsImportAs field of the objects in contractFile.dependencies
+ *
+ * @param {object[]} contractFiles - list of file objects
+ * @return {boolean} true if a file is using import 'as syntax', false otherwise
+ */
+const existsFileUsingImportAs = contractFiles => (
+  contractFiles.some(contractFile => (
+    contractFile.dependencies.some(dep => dep.containsImportAs)
+  ))
+);
+
+/**
  * for each solidity file found in srcDir, create solidity file in which all
  * dependencies of that file + the orignal file's content are written, in the correct order
  *
@@ -228,6 +241,11 @@ const alterNameForCombine = filename => (
 const combine = ({ srcDir, depDir, destDir }) => {
   // get all files in the provided source directory and all its subdirectories
   const contractFiles = getContractFiles(srcDir);
+
+  if (existsFileUsingImportAs(contractFiles)) {
+    console.log('\nfiles containing imports using \'as\' cannot be combined, e.g. import { X as Y } from "./Contract.sol"\n');
+    process.exit(1);
+  }
 
   // get a list of file paths of node_modules dependencies found in the contract files
   const depPaths = getDepPaths(contractFiles);

--- a/lib/flatten.js
+++ b/lib/flatten.js
@@ -9,6 +9,7 @@ const {
   getDepPaths,
   retrieveNestedDeps,
   generateNodeModuleVersionComments,
+  regexImportTarget,
 } = require('./shared');
 
 /**
@@ -54,8 +55,8 @@ const replaceImports = (allFiles, targetFile) => (
         // get the file item
         const fileItem = allFiles.find(file => file.path === importPath);
 
-        // replace the import line
-        return `import './${fileItem.name}';`;
+        // replace the import line target, leaving all else as it were
+        return line.replace(regexImportTarget, `'./${fileItem.name}'`);
       }
 
       return line;

--- a/lib/shared.js
+++ b/lib/shared.js
@@ -99,11 +99,17 @@ const getNodeModuleVersion = (depDir, nodeModuleName) => (
  * @return {string} the extracted import target
  */
 const extractImportTarget = importLine => (
-  importLine
-    // remove preceding import statement
-    .replace('import ', '')
-    // remove quotation marks and semicolon
-    .replace(/['";]/g, '')
+  regexImportTarget.exec(importLine.replace(/'/g, '"'))[1]
+);
+
+/**
+ * given an import line check if the import is using { X as Y } syntax
+ *
+ * @param {string} importLine - the import line string
+ * @return {boolean} true if it contains 'as' syntax, false otherwise
+ */
+const containsImportAs = importLine => (
+  /[_a-zA-Z]{1}[_a-zA-Z0-9]* as [_a-zA-Z]{1}[_a-zA-Z0-9]*/.test(importLine)
 );
 
 /**
@@ -121,6 +127,8 @@ const extractImports = (isNodeModule, fileContent, subDirPath) => (
       if (line.startsWith('import')) {
         // add import file path to memo
         const importInfo = {
+          // keep track of this since the combine feature can't handle import 'as' syntax
+          containsImportAs: containsImportAs(line),
           target: extractImportTarget(line),
         };
 

--- a/lib/shared.js
+++ b/lib/shared.js
@@ -3,6 +3,9 @@ const fs = require('fs');
 const path = require('path');
 const mkdirp = require('mkdirp');
 
+/** used in: @see extractImportTarget, @see replaceImports (in flatten.js) */
+const regexImportTarget = /"([a-zA-Z_\-\/\\.\\d]+)"/; // eslint-disable-line no-useless-escape
+
 /**
  * check if a given path is of a file
  *
@@ -352,4 +355,5 @@ module.exports = {
   getDepPaths,
   retrieveNestedDeps,
   generateNodeModuleVersionComments,
+  regexImportTarget,
 };


### PR DESCRIPTION
### Issue #4 

### Changes
- correctly dealing with `import { X as Y } from "./Contract.sol"` syntax.
- disallowing import as syntax when using the `combine` command since there is no way to `X as Y` when placing all dependencies inside 1 file!

  